### PR TITLE
Add default values to user factory

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :user do
-    
+    email { Faker::Internet.email }
+    password { Faker::Internet.password }
+    name { Faker::Name.name }
+    registered_at { Time.now }    
   end
 end


### PR DESCRIPTION
- Add default values to the users factory in order to simplify specs involving a `User`