### PR TITLE
Add date column to TimelineItem in order to sort returned timeline items

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
         @comment.commented_at = Time.now
 
         if @comment.save
-            TimelineItem.create timelineable: @comment, event: TimelineItem::COMMENT_ON_POST, user: @comment.user
+            TimelineItem.create timelineable: @comment, event: TimelineItem::COMMENT_ON_POST, user: @comment.user, date: Time.now
 
             render json: @comment, status: 200
         else

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
         @post.posted_at = Time.now
 
         if @post.save
-            timeline_item = TimelineItem.new timelineable: @post, event: TimelineItem::CREATE_POST, user: @post.user
+            timeline_item = TimelineItem.new timelineable: @post, event: TimelineItem::CREATE_POST, user: @post.user, date: Time.now
             if !timeline_item.save
                 return render json: { errors: { message: @timeline_item.errors.full_messages} }, status: 400
             end

--- a/app/controllers/user_ratings_controller.rb
+++ b/app/controllers/user_ratings_controller.rb
@@ -6,7 +6,7 @@ class UserRatingsController < ApplicationController
         if @user_rating.save
             user_average = @user_rating.user.average_rating
             if user_average > 4.0
-                TimelineItem.create timelineable: @user_rating.user, event: TimelineItem::SURPASS_4_STARS, user: @user_rating.user
+                TimelineItem.create timelineable: @user_rating.user, event: TimelineItem::SURPASS_4_STARS, user: @user_rating.user, date: Time.now
             end
             
             render json: @user_rating

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
                 if !existing_github_ids.include? github_id
                     github_event = GithubEvent.create! repo_name: repo_name, branch: branch, event_name: GithubAPI::PUSH_COMMIT, github_id: github_id, user: user, date: event_date
 
-                    TimelineItem.create! timelineable: github_event, user: user, event: TimelineItem::PUSH_GITHUB_COMMITS_TO_BRANCH, message: "Pushed #{num_commits} #{"commit".pluralize(num_commits)} to #{repo_name} #{branch}" 
+                    TimelineItem.create! timelineable: github_event, user: user, event: TimelineItem::PUSH_GITHUB_COMMITS_TO_BRANCH, message: "Pushed #{num_commits} #{"commit".pluralize(num_commits)} to #{repo_name} #{branch}", date: event_date 
                 end
             end
 
@@ -42,7 +42,7 @@ class UsersController < ApplicationController
                 if !existing_github_ids.include? github_id
                     github_event = GithubEvent.create! repo_name: repo_name, event_name: GithubAPI::CREATE_REPO, github_id: github_id, user: user, date: event_date
 
-                    TimelineItem.create! timelineable: github_event, user: user, event: TimelineItem::CREATE_NEW_GITHUB_REPOSITORY, message: "Created a new repository #{repo_name}" 
+                    TimelineItem.create! timelineable: github_event, user: user, event: TimelineItem::CREATE_NEW_GITHUB_REPOSITORY, message: "Created a new repository #{repo_name}", date: event_date
                 end
             end
 
@@ -56,7 +56,7 @@ class UsersController < ApplicationController
                 if !existing_github_ids.include? github_id
                     github_event = GithubEvent.create! repo_name: repo_name, event_name: GithubAPI::CREATE_REPO, github_id: github_id, user: user, date: event_date
 
-                    TimelineItem.create! timelineable: github_event, user: user, event: TimelineItem::CREATE_NEW_GITHUB_REPOSITORY, message: "Opened a new Pull Request #{pr_number} for #{repo_name}" 
+                    TimelineItem.create! timelineable: github_event, user: user, event: TimelineItem::CREATE_NEW_GITHUB_REPOSITORY, message: "Opened a new Pull Request #{pr_number} for #{repo_name}", date: event_date 
                 end
             end
             
@@ -70,7 +70,7 @@ class UsersController < ApplicationController
                 if !existing_github_ids.include? github_id
                     github_event = GithubEvent.create! repo_name: repo_name, event_name: GithubAPI::CREATE_REPO, github_id: github_id, user: user, date: event_date
 
-                    TimelineItem.create! timelineable: github_event, user: user, event: TimelineItem::CREATE_NEW_GITHUB_REPOSITORY, message: "Merged #{pr_number} into #{repo_name}" 
+                    TimelineItem.create! timelineable: github_event, user: user, event: TimelineItem::CREATE_NEW_GITHUB_REPOSITORY, message: "Merged #{pr_number} into #{repo_name}", date: event_date
                 end
             end
         end

--- a/db/migrate/20240913113254_add_date_to_timeline_item.rb
+++ b/db/migrate/20240913113254_add_date_to_timeline_item.rb
@@ -1,0 +1,5 @@
+class AddDateToTimelineItem < ActiveRecord::Migration[7.1]
+  def change
+    add_column :timeline_items, :date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_12_121600) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_13_113254) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_121600) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.string "message"
+    t.datetime "date"
     t.index ["timelineable_type", "timelineable_id"], name: "index_timeline_items_on_timelineable"
     t.index ["user_id"], name: "index_timeline_items_on_user_id"
   end

--- a/spec/models/timeline_item_spec.rb
+++ b/spec/models/timeline_item_spec.rb
@@ -13,6 +13,5 @@ RSpec.describe TimelineItem, type: :model do
       expect(timeline_item.timelineable).to eq timelineable
       expect(timeline_item.event).to eq TimelineItem::CREATE_POST
     }.to change {TimelineItem.count}.from(0).to(1)
-
   end
 end


### PR DESCRIPTION
Although `created_at` will be identical to `date` for local actions (such as creating a post or commenting on a post), the `date` column on `TimelineItem` will match the `created_at` value for Github public events. As such, **this change allows the timeline items returned by `/users/:id/timeline` to be sorted reverse chronologically in a reliable fashion.**