### PR TITLE
Prevent duplicate ratings

### DIFF
--- a/app/controllers/user_ratings_controller.rb
+++ b/app/controllers/user_ratings_controller.rb
@@ -3,6 +3,10 @@ class UserRatingsController < ApplicationController
         if user_ratings_params[:user_id] == user_ratings_params[:rater_id]
             return render json: { error: { message: "You cannot rate yourself."} }, status: 400
         end
+
+        if UserRating.where(user_id: user_ratings_params[:user_id], rater_id: user_ratings_params[:rater_id]).present?
+            return render json: { error: { message: "You have already rated this user."} }, status: 400
+        end
         
         @user_rating = UserRating.new(user_ratings_params)
         @user_rating.rated_at = Time.now


### PR DESCRIPTION
As an improvement, allow a user to re-rate another user within a certain interval (I.e. 3 months)